### PR TITLE
Add missing permissions

### DIFF
--- a/master/TerraformInit-IAM-Policy.txt
+++ b/master/TerraformInit-IAM-Policy.txt
@@ -10,7 +10,11 @@
                 "organizations:CreateAccount",
                 "organizations:ListAccounts",
                 "organizations:DescribeAccount",
-                "organizations:DescribeCreateAccountStatus"
+                "organizations:DescribeCreateAccountStatus",
+                "organizations:ListRoots",
+                "organizations:ListAWSServiceAccessForOrganization",
+                "organizations:ListParents",
+                "organizations:ListTagsForResource",
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Running `init.sh` script on a pristine AWS account to create organization and associated sub accounts (infosec, prod and non-prod) resulted in a number of access violations. Adding permissions in this PR to the policy attached to `terraform-init` user solved the access issues and allowed successful creation of organization and account structure.