### PR TITLE
Remove invalid trailing comma

### DIFF
--- a/master/TerraformInit-IAM-Policy.txt
+++ b/master/TerraformInit-IAM-Policy.txt
@@ -14,7 +14,7 @@
                 "organizations:ListRoots",
                 "organizations:ListAWSServiceAccessForOrganization",
                 "organizations:ListParents",
-                "organizations:ListTagsForResource",
+                "organizations:ListTagsForResource"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
The trailing comma introduced in PR #8 causes the following error in the AWS policy editor when creating the TerraformInit policy:

`This policy contains the following JSON error on line 72: JSON.parse: unexpected character at line 18 column 13 of the JSON data`