### PR TITLE
Fix: privs update to allow terragrunt to complete

### DIFF
--- a/master/TerraformInit-IAM-Policy.txt
+++ b/master/TerraformInit-IAM-Policy.txt
@@ -49,7 +49,9 @@
                 "iam:GetRole",
                 "iam:CreateRole",
                 "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
                 "iam:AttachRolePolicy",
+                "iam:ListInstanceProfilesForRole",
                 "iam:UpdateAssumeRolePolicy"
             ],
             "Resource": [


### PR DESCRIPTION
I was unable to get terragrunt to apply in `aws-accounts-terraform/master/organization`

These privs seem to have resolved the issue and also seem safe.  I'm admittedly using an older version of terraform (.13), however given the commit history that seems to be a version that would be ideal to make things work.

Please let me know if for some reason this can't be merged, I would be curious as to why.

Thanks!
Matt